### PR TITLE
Bug fix for Trello card #330

### DIFF
--- a/swotann/nnetwork.py
+++ b/swotann/nnetwork.py
@@ -2241,7 +2241,7 @@ class NNetwork(object):
 
             elif WATTEMP in self.datainputs.columns:
                 hist_fig, (ax1, ax2, ax3, ax4, ax5) = plt.subplots(
-                    6, 1, figsize=(3.35, 6.69), dpi=300
+                    5, 1, figsize=(3.35, 6.69), dpi=300
                 )
 
                 ax1.set_ylabel("Frequency")
@@ -2304,7 +2304,7 @@ class NNetwork(object):
 
             elif COND in self.datainputs.columns:
                 hist_fig, (ax1, ax2, ax3, ax4, ax5) = plt.subplots(
-                    6, 1, figsize=(3.35, 6.69), dpi=300
+                    5, 1, figsize=(3.35, 6.69), dpi=300
                 )
 
                 ax1.set_ylabel("Frequency")


### PR DESCRIPTION
Only change is fixing the number of subplots for the histograms with only one additional WQ variable (i.e., conductivity OR water temperature)